### PR TITLE
Add point_size_not_clamped

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,5 +13,5 @@ This file is an overview of issues defined in `errata/*.yaml`, sorted by importa
 
 | Name | Severity | Category | Affected Drivers | Affected Platforms | Fixed in latest drivers? |
 |------|:--------:|:--------:|:----------------:|:------------------:|:------------------------:|
-
+| [`point_size_not_clamped`](point_size_not_clamped.md) | low | rendering | NvidiaProprietary | Linux, Windows | Yes |
 

--- a/doc/point_size_not_clamped.md
+++ b/doc/point_size_not_clamped.md
@@ -1,0 +1,31 @@
+# The `point_size_not_clamped` Bug
+
+## Description
+
+The Vulkan specification [says][spec]:
+
+> The point size is taken from the (potentially clipped) shader built-in `PointSize` written by:
+>
+> * the geometry shader, if active;
+> * the tessellation evaluation shader, if active and no geometry shader is active;
+> * the vertex shader, otherwise
+>
+> and clamped to the implementation-dependent point size range
+> `[pointSizeRange[0],pointSizeRange[1]]`.
+
+In the above quote, `pointSizeRange` references `VkPhysicalDeviceLimits::pointSizeRange`.
+
+On some implementations, the above clamping is not done.
+
+[spec]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap28.html#primsrast-points
+
+## Bug Side Effect
+
+The side effect of this bug is that if a shader outputs to the `PointSize` shader built-in with a
+value that is outside the range reported in `VkPhysicalDeviceLimits::pointSizeRange`, incorrect
+rendering is done for that point only.
+
+## Known Workarounds
+
+This bug can be worked around by making sure that the shader clamps the value written to `PointSize`
+with the values retrieved from `VkPhysicalDeviceLimits::pointSizeRange`.

--- a/errata/point_size_not_clamped.yaml
+++ b/errata/point_size_not_clamped.yaml
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+---
+point_size_not_clamped:
+  description: >
+    The PointSize shader built-in is not clamped to the API-specified limit as
+    required.
+  category: rendering
+  severity: low
+  affected:
+    - driver: VK_DRIVER_ID_NVIDIA_PROPRIETARY
+      platform: Linux
+      version_fixed: 421
+    - driver: VK_DRIVER_ID_NVIDIA_PROPRIETARY
+      platform: Windows
+      version_fixed: 430

--- a/src/vulkan-errata.c
+++ b/src/vulkan-errata.c
@@ -115,6 +115,12 @@ VkResult vulkanErrataGetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->point_size_not_clamped.affected = (isNvidiaProprietary && isLinux && device->driverVersion < NvidiaProprietaryVersion(421,0,0,0)) ||
+        (isNvidiaProprietary && isWindows && device->driverVersion < NvidiaProprietaryVersion(430,0,0,0));
+    issues->point_size_not_clamped.name = "point_size_not_clamped";
+    issues->point_size_not_clamped.camelCaseName = "pointSizeNotClamped";
+    issues->point_size_not_clamped.description = "The PointSize shader built-in is not clamped to the API-specified limit as required.";
+    issues->point_size_not_clamped.condition = "(isNvidiaProprietary && isLinux && device->driverVersion < NvidiaProprietaryVersion(421,0,0,0)) || (isNvidiaProprietary && isWindows && device->driverVersion < NvidiaProprietaryVersion(430,0,0,0))";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.cpp
+++ b/src/vulkan-errata.cpp
@@ -115,6 +115,12 @@ VkResult GetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->point_size_not_clamped.affected = (isNvidiaProprietary && isLinux && device->driverVersion < NvidiaProprietaryVersion(421,0,0,0)) ||
+        (isNvidiaProprietary && isWindows && device->driverVersion < NvidiaProprietaryVersion(430,0,0,0));
+    issues->point_size_not_clamped.name = "point_size_not_clamped";
+    issues->point_size_not_clamped.camelCaseName = "pointSizeNotClamped";
+    issues->point_size_not_clamped.description = "The PointSize shader built-in is not clamped to the API-specified limit as required.";
+    issues->point_size_not_clamped.condition = "(isNvidiaProprietary && isLinux && device->driverVersion < NvidiaProprietaryVersion(421,0,0,0)) || (isNvidiaProprietary && isWindows && device->driverVersion < NvidiaProprietaryVersion(430,0,0,0))";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.h
+++ b/src/vulkan-errata.h
@@ -43,7 +43,7 @@ typedef struct VulkanErrataKnownIssue
 
 typedef struct VulkanErrataKnownIssues
 {
-
+    struct VulkanErrataKnownIssue point_size_not_clamped;
 } VulkanErrataKnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/src/vulkan-errata.hpp
+++ b/src/vulkan-errata.hpp
@@ -41,7 +41,7 @@ typedef struct KnownIssue
 
 typedef struct KnownIssues
 {
-
+    struct KnownIssue point_size_not_clamped;
 } KnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -121,3 +121,77 @@ TEST(Errata, NegativeAPI)
     result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
     EXPECT_EQ(result, VK_ERROR_INCOMPATIBLE_DRIVER);
 }
+
+TEST(Errata, NoDriverInfo)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(NvidiaProprietaryVersion(400, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    VulkanErrataKnownIssues issues = {};
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, nullptr, &issues);
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.point_size_not_clamped.affected);
+
+    device = MakeDevice(NvidiaProprietaryVersion(500, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformWindows, &device, nullptr, &issues);
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.point_size_not_clamped.affected);
+}
+
+TEST(Errata, NvidiaProprietary_400)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(NvidiaProprietaryVersion(400, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, "NVIDIA", "NVIDIA",
+            VkConformanceVersion{1, 3, 0, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.point_size_not_clamped.affected);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.name, "point_size_not_clamped"), 0);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.camelCaseName, "pointSizeNotClamped"), 0);
+    EXPECT_NE(strcmp(issues.point_size_not_clamped.description, ""), 0);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Nvidia"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Linux"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Windows"), nullptr);
+
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformWindows, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.point_size_not_clamped.affected);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.name, "point_size_not_clamped"), 0);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.camelCaseName, "pointSizeNotClamped"), 0);
+    EXPECT_NE(strcmp(issues.point_size_not_clamped.description, ""), 0);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Nvidia"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Linux"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Windows"), nullptr);
+}
+
+TEST(Errata, NvidiaProprietary_500)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(NvidiaProprietaryVersion(500, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, "NVIDIA", "NVIDIA",
+            VkConformanceVersion{1, 3, 0, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.point_size_not_clamped.affected);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.name, "point_size_not_clamped"), 0);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.camelCaseName, "pointSizeNotClamped"), 0);
+    EXPECT_NE(strcmp(issues.point_size_not_clamped.description, ""), 0);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Nvidia"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Linux"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Windows"), nullptr);
+
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformWindows, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.point_size_not_clamped.affected);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.name, "point_size_not_clamped"), 0);
+    EXPECT_EQ(strcmp(issues.point_size_not_clamped.camelCaseName, "pointSizeNotClamped"), 0);
+    EXPECT_NE(strcmp(issues.point_size_not_clamped.description, ""), 0);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Nvidia"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Linux"), nullptr);
+    EXPECT_NE(strstr(issues.point_size_not_clamped.condition, "Windows"), nullptr);
+}


### PR DESCRIPTION
## Add point_size_not_clamped

Nvidia driver bug where gl_PointSize is not clamped as it should.

## Reporter Checklist:

Please ensure the following points are checked:

- [x] I have reviewed the [license](https://github.com/google/Vulkan-Errata/tree/master/LICENSE)
- [x] I have reported this bug to the IHV(s) and they have confirmed the bug
  - [x] Link to bug report: http://anglebug.com/2970
  - [ ] This bug has been hit by an application (i.e. not only tests)
- [x] I have created an entry under `errata/<name>.yaml` with as much information as available to me
- [x] I have added documentation on the bug under `doc/<name>.md`, including issue workaround
- [x] I have added tests in `tests/tests.cpp` to make sure the bug is detected appropriately

## Reviewer Checklist

Please leave the following items for the reviewer(s) to check:

- [ ] The new `.yaml` files are appropriately licensed
- [ ] The IHV(s) confirm this bug
- [ ] The tests cover both positive and negative cases
- [ ] A CTS issue is added for coverage: TODO link
