### PR TITLE
Add flipped_present_region_rectangle_origin

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,5 +13,5 @@ This file is an overview of issues defined in `errata/*.yaml`, sorted by importa
 
 | Name | Severity | Category | Affected Drivers | Affected Platforms | Fixed in latest drivers? |
 |------|:--------:|:--------:|:----------------:|:------------------:|:------------------------:|
-
+| [`flipped_present_region_rectangle_origin`](flipped_present_region_rectangle_origin.md) | high | rendering | All | Android | No |
 

--- a/doc/flipped_present_region_rectangle_origin.md
+++ b/doc/flipped_present_region_rectangle_origin.md
@@ -1,0 +1,28 @@
+# The `flipped_present_region_rectangle_origin` Bug
+
+## Description
+
+The `VK_KHR_incremental_present` extension is the Vulkan equivalent of
+`EGL_KHR_swap_buffers_with_damage`.  In EGL, the coordinates follow OpenGL's bottom-left origin
+convention.  In Vulkan however, the coordinates follow Vulkan's top-left origin convention.
+
+[Issue #2][spec] in the extension specification clarifies this:
+
+> 2) Where is the origin of the VkRectLayerKHR?
+>
+> RESOLVED: The upper left corner of the presentable image(s) of the swapchain, per the definition of framebuffer coordinates.
+
+On some implementations, the Vulkan implementation uses the EGL convention.
+
+[spec]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap54.html#VK_KHR_incremental_present
+
+## Bug Side Effect
+
+The side effect of this bug is that damage rectangles are flipped in the Y axis, resulting in
+incorrect areas of the swapchain being identified as modified.  The actually modified region may not
+be updated on the screen as a result.
+
+## Known Workarounds
+
+This bug can be worked around by using `swapchain_height - (offset.y + extent.height)` as `offset.y`
+in `VkRectLayerKHR`.

--- a/errata/flipped_present_region_rectangle_origin.yaml
+++ b/errata/flipped_present_region_rectangle_origin.yaml
@@ -1,0 +1,13 @@
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+---
+flipped_present_region_rectangle_origin:
+  description: >
+    The rectangles passed in VkPresentRegionKHR are processed as if having a
+    bottom-left origin (as in EGL) instead of a top-left origin (per Vulkan).
+  category: rendering
+  severity: high
+  affected:
+    - platform: Android

--- a/src/vulkan-errata.c
+++ b/src/vulkan-errata.c
@@ -115,6 +115,11 @@ VkResult vulkanErrataGetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->flipped_present_region_rectangle_origin.affected = (isAndroid);
+    issues->flipped_present_region_rectangle_origin.name = "flipped_present_region_rectangle_origin";
+    issues->flipped_present_region_rectangle_origin.camelCaseName = "flippedPresentRegionRectangleOrigin";
+    issues->flipped_present_region_rectangle_origin.description = "The rectangles passed in VkPresentRegionKHR are processed as if having a bottom-left origin (as in EGL) instead of a top-left origin (per Vulkan).";
+    issues->flipped_present_region_rectangle_origin.condition = "(isAndroid)";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.cpp
+++ b/src/vulkan-errata.cpp
@@ -115,6 +115,11 @@ VkResult GetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->flipped_present_region_rectangle_origin.affected = (isAndroid);
+    issues->flipped_present_region_rectangle_origin.name = "flipped_present_region_rectangle_origin";
+    issues->flipped_present_region_rectangle_origin.camelCaseName = "flippedPresentRegionRectangleOrigin";
+    issues->flipped_present_region_rectangle_origin.description = "The rectangles passed in VkPresentRegionKHR are processed as if having a bottom-left origin (as in EGL) instead of a top-left origin (per Vulkan).";
+    issues->flipped_present_region_rectangle_origin.condition = "(isAndroid)";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.h
+++ b/src/vulkan-errata.h
@@ -43,7 +43,7 @@ typedef struct VulkanErrataKnownIssue
 
 typedef struct VulkanErrataKnownIssues
 {
-
+    struct VulkanErrataKnownIssue flipped_present_region_rectangle_origin;
 } VulkanErrataKnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/src/vulkan-errata.hpp
+++ b/src/vulkan-errata.hpp
@@ -41,7 +41,7 @@ typedef struct KnownIssue
 
 typedef struct KnownIssues
 {
-
+    struct KnownIssue flipped_present_region_rectangle_origin;
 } KnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -121,3 +121,19 @@ TEST(Errata, NegativeAPI)
     result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
     EXPECT_EQ(result, VK_ERROR_INCOMPATIBLE_DRIVER);
 }
+
+TEST(Errata, Android)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(42, 0), VENDOR_ARM, DEVICE_unspecified);
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, nullptr, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.flipped_present_region_rectangle_origin.affected);
+
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, nullptr, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.flipped_present_region_rectangle_origin.affected);
+}


### PR DESCRIPTION
## Add flipped_present_region_rectangle_origin

Android bug where present region rectangles are flipped (using the OpenGL coordinate system).

## Reporter Checklist:

Please ensure the following points are checked:

- [x] I have reviewed the [license](https://github.com/google/Vulkan-Errata/tree/master/LICENSE)
- [x] I have reported this bug to the IHV(s) and they have confirmed the bug
  - [x] Link to bug report: http://anglebug.com/6933
  - [x] This bug has been hit by an application (i.e. not only tests)
- [x] I have created an entry under `errata/<name>.yaml` with as much information as available to me
- [x] I have added documentation on the bug under `doc/<name>.md`, including issue workaround
- [x] I have added tests in `tests/tests.cpp` to make sure the bug is detected appropriately

## Reviewer Checklist

Please leave the following items for the reviewer(s) to check:

- [ ] The new `.yaml` files are appropriately licensed
- [ ] The IHV(s) confirm this bug
- [ ] The tests cover both positive and negative cases
- [ ] A CTS issue is added for coverage: TODO link
