### PR TITLE
Add incorrect_dynamic_stencil_write_mask_state

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,5 +13,5 @@ This file is an overview of issues defined in `errata/*.yaml`, sorted by importa
 
 | Name | Severity | Category | Affected Drivers | Affected Platforms | Fixed in latest drivers? |
 |------|:--------:|:--------:|:----------------:|:------------------:|:------------------------:|
-
+| [`incorrect_dynamic_stencil_write_mask_state`](incorrect_dynamic_stencil_write_mask_state.md) | low | rendering | ArmProprietary | All | Yes |
 

--- a/doc/incorrect_dynamic_stencil_write_mask_state.md
+++ b/doc/incorrect_dynamic_stencil_write_mask_state.md
@@ -1,0 +1,20 @@
+# The `incorrect_dynamic_stencil_write_mask_state` Bug
+
+## Description
+
+When the stencil write mask state is dynamic (`VK_DYNAMIC_STATE_STENCIL_WRITE_MASK`), the static
+state provided when creating the pipeline must be ignored.
+
+On some implementations, when the static state is 0, the pipeline is created such that it is unable
+to avoid writing to stencil when a pixel is discarded.
+
+## Bug Side Effect
+
+The side effect of this bug is that when a shader discards a fragment, or when alpha-to-coverage is
+used, the stencil value is still written to the fragments that were expected to be discarded.
+
+## Known Workarounds
+
+This bug can be worked around by placing any non-zero value in `VkStencilOpState::writeMask` when
+creating a pipeline with `VK_DYNAMIC_STATE_STENCIL_WRITE_MASK` (even though that value was supposed
+to be ignored).

--- a/errata/incorrect_dynamic_stencil_write_mask_state.yaml
+++ b/errata/incorrect_dynamic_stencil_write_mask_state.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+---
+incorrect_dynamic_stencil_write_mask_state:
+  description: >
+    A value of 0 in the (unused) stencil write mask static state makes the
+    corresponding dynamic state malfunction in the presence of discard or alpha
+    to coverage.
+  category: rendering
+  severity: low
+  affected:
+    - driver: VK_DRIVER_ID_ARM_PROPRIETARY
+      version_fixed: 43

--- a/src/vulkan-errata.c
+++ b/src/vulkan-errata.c
@@ -115,6 +115,11 @@ VkResult vulkanErrataGetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->incorrect_dynamic_stencil_write_mask_state.affected = (isArmProprietary && device->driverVersion < ArmProprietaryVersion(43,0,0,0));
+    issues->incorrect_dynamic_stencil_write_mask_state.name = "incorrect_dynamic_stencil_write_mask_state";
+    issues->incorrect_dynamic_stencil_write_mask_state.camelCaseName = "incorrectDynamicStencilWriteMaskState";
+    issues->incorrect_dynamic_stencil_write_mask_state.description = "A value of 0 in the (unused) stencil write mask static state makes the corresponding dynamic state malfunction in the presence of discard or alpha to coverage.";
+    issues->incorrect_dynamic_stencil_write_mask_state.condition = "(isArmProprietary && device->driverVersion < ArmProprietaryVersion(43,0,0,0))";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.cpp
+++ b/src/vulkan-errata.cpp
@@ -115,6 +115,11 @@ VkResult GetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->incorrect_dynamic_stencil_write_mask_state.affected = (isArmProprietary && device->driverVersion < ArmProprietaryVersion(43,0,0,0));
+    issues->incorrect_dynamic_stencil_write_mask_state.name = "incorrect_dynamic_stencil_write_mask_state";
+    issues->incorrect_dynamic_stencil_write_mask_state.camelCaseName = "incorrectDynamicStencilWriteMaskState";
+    issues->incorrect_dynamic_stencil_write_mask_state.description = "A value of 0 in the (unused) stencil write mask static state makes the corresponding dynamic state malfunction in the presence of discard or alpha to coverage.";
+    issues->incorrect_dynamic_stencil_write_mask_state.condition = "(isArmProprietary && device->driverVersion < ArmProprietaryVersion(43,0,0,0))";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.h
+++ b/src/vulkan-errata.h
@@ -43,7 +43,7 @@ typedef struct VulkanErrataKnownIssue
 
 typedef struct VulkanErrataKnownIssues
 {
-
+    struct VulkanErrataKnownIssue incorrect_dynamic_stencil_write_mask_state;
 } VulkanErrataKnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/src/vulkan-errata.hpp
+++ b/src/vulkan-errata.hpp
@@ -41,7 +41,7 @@ typedef struct KnownIssue
 
 typedef struct KnownIssues
 {
-
+    struct KnownIssue incorrect_dynamic_stencil_write_mask_state;
 } KnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -121,3 +121,42 @@ TEST(Errata, NegativeAPI)
     result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
     EXPECT_EQ(result, VK_ERROR_INCOMPATIBLE_DRIVER);
 }
+
+TEST(Errata, ArmProprietary_38)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(38, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.incorrect_dynamic_stencil_write_mask_state.affected);
+}
+
+TEST(Errata, ArmProprietary_42)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(42, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.incorrect_dynamic_stencil_write_mask_state.affected);
+}
+
+TEST(Errata, ArmProprietary_43)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(43, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.incorrect_dynamic_stencil_write_mask_state.affected);
+}


### PR DESCRIPTION
## Add incorrect_dynamic_stencil_write_mask_state

When 0 is used as value for static state for stencil write mask, it is not ignored, and interferes with dynamic stencil write mask.

## Reporter Checklist:

Please ensure the following points are checked:

- [x] I have reviewed the [license](https://github.com/google/Vulkan-Errata/tree/master/LICENSE)
- [x] I have reported this bug to the IHV(s) and they have confirmed the bug
  - [x] Link to bug report: https://issuetracker.google.com/issues/279715714
  - [x] This bug has been hit by an application (i.e. not only tests)
- [x] I have created an entry under `errata/<name>.yaml` with as much information as available to me
- [x] I have added documentation on the bug under `doc/<name>.md`, including issue workaround
- [x] I have added tests in `tests/tests.cpp` to make sure the bug is detected appropriately

## Reviewer Checklist

Please leave the following items for the reviewer(s) to check:

- [ ] The new `.yaml` files are appropriately licensed
- [ ] The IHV(s) confirm this bug
- [ ] The tests cover both positive and negative cases
- [ ] A CTS issue is added for coverage: TODO link
