### PR TITLE
Add get_query_result_does_not_wait_for_completion

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,5 +13,5 @@ This file is an overview of issues defined in `errata/*.yaml`, sorted by importa
 
 | Name | Severity | Category | Affected Drivers | Affected Platforms | Fixed in latest drivers? |
 |------|:--------:|:--------:|:----------------:|:------------------:|:------------------------:|
-
+| [`get_query_result_does_not_wait_for_completion`](get_query_result_does_not_wait_for_completion.md) | low | rendering | ArmProprietary, NvidiaProprietary | All | Some |
 

--- a/doc/get_query_result_does_not_wait_for_completion.md
+++ b/doc/get_query_result_does_not_wait_for_completion.md
@@ -1,0 +1,20 @@
+# The `get_query_result_does_not_wait_for_completion` Bug
+
+## Description
+
+When a submission is made that writes to a query, the `vkGetQueryPoolResults` command can be used
+with `VK_QUERY_RESULT_WAIT_BIT` to wait for the query results to be available.
+
+When this call is made before the device is finished processing the commands, on some
+implementations this function instead returns `VK_NOT_READY`.  On some other implementations, it
+returns incorrect results.
+
+## Bug Side Effect
+
+The side effect of this bug is that the query results are not obtained correctly.  The application's
+following calculations that depend on these values would be incorrect.
+
+## Known Workarounds
+
+This bug can be worked around by ensuring that the submission writing to the query is finished
+first.  This can be done by waiting on the submissions corresponding fence.

--- a/errata/get_query_result_does_not_wait_for_completion.yaml
+++ b/errata/get_query_result_does_not_wait_for_completion.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# SPDX-License-Identifier: CC-BY-4.0
+
+---
+get_query_result_does_not_wait_for_completion:
+  description: >
+    Calling vkGetQueryPoolResults with VK_QUERY_RESULT_WAIT_BIT does not
+    correctly wait for query results to be available.
+  category: rendering
+  severity: low
+  affected:
+    - driver: VK_DRIVER_ID_NVIDIA_PROPRIETARY
+      version_fixed: 470
+    - driver: VK_DRIVER_ID_ARM_PROPRIETARY

--- a/src/vulkan-errata.c
+++ b/src/vulkan-errata.c
@@ -115,6 +115,12 @@ VkResult vulkanErrataGetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->get_query_result_does_not_wait_for_completion.affected = (isNvidiaProprietary && device->driverVersion < NvidiaProprietaryVersion(470,0,0,0)) ||
+        (isArmProprietary);
+    issues->get_query_result_does_not_wait_for_completion.name = "get_query_result_does_not_wait_for_completion";
+    issues->get_query_result_does_not_wait_for_completion.camelCaseName = "getQueryResultDoesNotWaitForCompletion";
+    issues->get_query_result_does_not_wait_for_completion.description = "Calling vkGetQueryPoolResults with VK_QUERY_RESULT_WAIT_BIT does not correctly wait for query results to be available.";
+    issues->get_query_result_does_not_wait_for_completion.condition = "(isNvidiaProprietary && device->driverVersion < NvidiaProprietaryVersion(470,0,0,0)) || (isArmProprietary)";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.cpp
+++ b/src/vulkan-errata.cpp
@@ -115,6 +115,12 @@ VkResult GetKnownIssues(
     if (!isNvidiaProprietary && !isQualcommProprietary && !isArmProprietary && !isIntelOpenSourceMesa && !isSamsungProprietary)
         return VK_ERROR_INCOMPATIBLE_DRIVER;
 
+    issues->get_query_result_does_not_wait_for_completion.affected = (isNvidiaProprietary && device->driverVersion < NvidiaProprietaryVersion(470,0,0,0)) ||
+        (isArmProprietary);
+    issues->get_query_result_does_not_wait_for_completion.name = "get_query_result_does_not_wait_for_completion";
+    issues->get_query_result_does_not_wait_for_completion.camelCaseName = "getQueryResultDoesNotWaitForCompletion";
+    issues->get_query_result_does_not_wait_for_completion.description = "Calling vkGetQueryPoolResults with VK_QUERY_RESULT_WAIT_BIT does not correctly wait for query results to be available.";
+    issues->get_query_result_does_not_wait_for_completion.condition = "(isNvidiaProprietary && device->driverVersion < NvidiaProprietaryVersion(470,0,0,0)) || (isArmProprietary)";
 
     return VK_SUCCESS;
 }

--- a/src/vulkan-errata.h
+++ b/src/vulkan-errata.h
@@ -43,7 +43,7 @@ typedef struct VulkanErrataKnownIssue
 
 typedef struct VulkanErrataKnownIssues
 {
-
+    struct VulkanErrataKnownIssue get_query_result_does_not_wait_for_completion;
 } VulkanErrataKnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/src/vulkan-errata.hpp
+++ b/src/vulkan-errata.hpp
@@ -41,7 +41,7 @@ typedef struct KnownIssue
 
 typedef struct KnownIssues
 {
-
+    struct KnownIssue get_query_result_does_not_wait_for_completion;
 } KnownIssues;
 
 // Automatically fill in the struct fields based on platform, device and driver properties.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -121,3 +121,94 @@ TEST(Errata, NegativeAPI)
     result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
     EXPECT_EQ(result, VK_ERROR_INCOMPATIBLE_DRIVER);
 }
+
+TEST(Errata, NvidiaProprietary_400)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(NvidiaProprietaryVersion(400, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, "NVIDIA", "NVIDIA",
+            VkConformanceVersion{1, 3, 0, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.get_query_result_does_not_wait_for_completion.affected);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.name, "get_query_result_does_not_wait_for_completion"), 0);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.camelCaseName, "getQueryResultDoesNotWaitForCompletion"), 0);
+    EXPECT_NE(strcmp(issues.get_query_result_does_not_wait_for_completion.description, ""), 0);
+    EXPECT_NE(strstr(issues.get_query_result_does_not_wait_for_completion.condition, "Nvidia"), nullptr);
+
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformWindows, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.get_query_result_does_not_wait_for_completion.affected);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.name, "get_query_result_does_not_wait_for_completion"), 0);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.camelCaseName, "getQueryResultDoesNotWaitForCompletion"), 0);
+    EXPECT_NE(strcmp(issues.get_query_result_does_not_wait_for_completion.description, ""), 0);
+    EXPECT_NE(strstr(issues.get_query_result_does_not_wait_for_completion.condition, "Nvidia"), nullptr);
+}
+
+TEST(Errata, NvidiaProprietary_500)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(NvidiaProprietaryVersion(500, 0), VENDOR_NVIDIA, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY, "NVIDIA", "NVIDIA",
+            VkConformanceVersion{1, 3, 0, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformLinux, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.get_query_result_does_not_wait_for_completion.affected);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.name, "get_query_result_does_not_wait_for_completion"), 0);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.camelCaseName, "getQueryResultDoesNotWaitForCompletion"), 0);
+    EXPECT_NE(strcmp(issues.get_query_result_does_not_wait_for_completion.description, ""), 0);
+    EXPECT_NE(strstr(issues.get_query_result_does_not_wait_for_completion.condition, "Nvidia"), nullptr);
+
+    result = vulkanErrataGetKnownIssues(VulkanErrataPlatformWindows, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_FALSE(issues.get_query_result_does_not_wait_for_completion.affected);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.name, "get_query_result_does_not_wait_for_completion"), 0);
+    EXPECT_EQ(strcmp(issues.get_query_result_does_not_wait_for_completion.camelCaseName, "getQueryResultDoesNotWaitForCompletion"), 0);
+    EXPECT_NE(strcmp(issues.get_query_result_does_not_wait_for_completion.description, ""), 0);
+    EXPECT_NE(strstr(issues.get_query_result_does_not_wait_for_completion.condition, "Nvidia"), nullptr);
+}
+
+TEST(Errata, ArmProprietary_38)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(38, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.get_query_result_does_not_wait_for_completion.affected);
+}
+
+TEST(Errata, ArmProprietary_42)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(42, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.get_query_result_does_not_wait_for_completion.affected);
+}
+
+TEST(Errata, ArmProprietary_43)
+{
+    VkPhysicalDeviceProperties device = MakeDevice(ArmProprietaryVersion(43, 0), VENDOR_ARM, DEVICE_unspecified);
+    VkPhysicalDeviceDriverProperties driver = MakeDriver(VK_DRIVER_ID_ARM_PROPRIETARY, "ARM", "ARM",
+            VkConformanceVersion{1, 3, 6, 0});
+
+    VulkanErrataKnownIssues issues;
+    VkResult result = vulkanErrataGetKnownIssues(VulkanErrataPlatformAndroid, &device, &driver, &issues);
+
+    ASSERT_EQ(result, VK_SUCCESS);
+    EXPECT_TRUE(issues.get_query_result_does_not_wait_for_completion.affected);
+}


### PR DESCRIPTION
## Add get_query_result_does_not_wait_for_completion

vkGetQueryPoolResults with VK_QUERY_RESULT_WAIT_BIT does not actually wait.

## Reporter Checklist:

Please ensure the following points are checked:

- [x] I have reviewed the [license](https://github.com/google/Vulkan-Errata/tree/master/LICENSE)
- [x] I have reported this bug to the IHV(s) and they have confirmed the bug
  - [x] Link to bug report:
    * Arm: https://issuetracker.google.com/253522366
    * Nvidia: http://anglebug.com/6692
  - [ ] This bug has been hit by an application (i.e. not only tests)
- [x] I have created an entry under `errata/<name>.yaml` with as much information as available to me
- [x] I have added documentation on the bug under `doc/<name>.md`, including issue workaround
- [x] I have added tests in `tests/tests.cpp` to make sure the bug is detected appropriately

## Reviewer Checklist

Please leave the following items for the reviewer(s) to check:

- [ ] The new `.yaml` files are appropriately licensed
- [ ] The IHV(s) confirm this bug
- [ ] The tests cover both positive and negative cases
- [ ] A CTS issue is added for coverage: TODO link
